### PR TITLE
accessibility color contrast update in dark mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -166,3 +166,8 @@ h2:hover a#heading-hashtag,
 h3:hover a#heading-hashtag {
     display: revert;
 }
+
+/* Bootstrap dark mode WCAG compliance override */
+[data-bs-theme=dark] .text-bg-danger .card {
+    --bs-card-cap-bg: rgba(var(--bs-body-color-rgb), 0.0);
+}


### PR DESCRIPTION
override the opacity on the card header when it uses the red danger background and it is in dark mode because that fails WCAG AAA for some text sizes

Issue https://github.com/civichackingagency/scangov/issues/176